### PR TITLE
Fix 404 on service root

### DIFF
--- a/eCommerce.API/Program.cs
+++ b/eCommerce.API/Program.cs
@@ -62,4 +62,7 @@ app.UseAuthorization();
 // Controller routes
 app.MapControllers();
 
+// Redirect root requests to Swagger UI for convenience
+app.MapGet("/", () => Results.Redirect("/swagger"));
+
 app.Run();


### PR DESCRIPTION
## Summary
- redirect `/` to the Swagger UI so visiting the root doesn't return 404

## Testing
- `dotnet test` *(fails: `dotnet` not found)*